### PR TITLE
feat: integrate Terminal Bench suite adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-`nearai-bench` — a Rust benchmarking harness for evaluating AI agents across multiple suite types (trajectory, spot, custom, gaia, tau_bench, swe_bench). Extracted from the [ironclaw](https://github.com/nearai/ironclaw) agent framework and depends on it as a library.
+`nearai-bench` — a Rust benchmarking harness for evaluating AI agents across multiple suite types (trajectory, spot, custom, gaia, tau_bench, swe_bench, terminal_bench). Extracted from the [ironclaw](https://github.com/nearai/ironclaw) agent framework and depends on it as a library.
 
 ## Build & Run
 
@@ -65,6 +65,7 @@ Auto-deploys on push to `main` when `results/`, `baselines/`, or `site/` change 
 - `instrumented_llm.rs` — Wraps an `LlmProvider` to track token counts and costs.
 - `channel.rs` — `BenchChannel` implements ironclaw's channel interface to capture agent responses and tool calls.
 - `openclaw.rs` — Docker lifecycle management and HTTP client for running tasks against an OpenClaw gateway container. Creates per-task containers with identity files and auth profiles.
+- `docker.rs` — Shared Docker utilities (build, run, exec, cleanup) used by the Terminal Bench adapter.
 
 **Data layout:**
 - `datasets/{suite}/v{N}/` — versioned benchmark data (JSONL or directories)
@@ -120,6 +121,55 @@ Optional `[openclaw]` section in suite TOML to override defaults:
 image = "openclaw:local"       # Docker image (default: openclaw:local)
 gateway_token = "my-token"     # Gateway auth token (default: bench-token)
 ```
+
+### Terminal Bench
+
+[Terminal Bench](https://github.com/harbor-framework/terminal-bench) evaluates agents on real terminal tasks (compiling code, training models, setting up servers). Each task runs in its own Docker container. The harness builds the container, the agent executes shell commands inside it via `docker exec`, then a test script verifies success.
+
+**Prerequisites:** Docker must be installed and running.
+
+**Dataset setup:**
+```bash
+# Clone Terminal Bench tasks into the datasets directory
+git clone --depth 1 https://github.com/harbor-framework/terminal-bench /tmp/terminal-bench
+cp -r /tmp/terminal-bench/tasks datasets/terminal-bench/v1
+
+# Or point dataset_path directly at a local checkout
+```
+
+Both Harbor/TB2 format (`task.toml` + `instruction.md` + `environment/Dockerfile`) and legacy format (`task.yaml` + `docker-compose.yaml`) are supported.
+
+**Running with ironclaw:**
+```bash
+cargo run -- run --suite terminal_bench --config suites/terminal-bench.toml
+```
+
+The agent gets `shell`, `read_file`, and `write_file` tools that execute inside the task's Docker container transparently.
+
+**Running with openclaw:**
+```bash
+cargo run -- run --suite terminal_bench \
+  --config suites/terminal-bench.toml \
+  --framework openclaw \
+  --model openrouter/anthropic/claude-sonnet-4
+```
+
+For openclaw, the Docker socket is mounted into the openclaw container and the prompt is prepended with instructions to use `docker exec` targeting the task container.
+
+**Suite config options (`suites/terminal-bench.toml`):**
+```toml
+task_timeout = "600s"       # Default per-task timeout
+parallelism = 1             # Docker builds are heavy; keep low
+
+[suite_config]
+dataset_path = "datasets/terminal-bench/v1"
+rebuild_images = false      # Set true to force Docker image rebuilds
+verifier_timeout = "300s"   # Timeout for test scripts
+```
+
+**Scoring:** Tasks are scored via reward files written by test scripts:
+- `/logs/verifier/reward.txt` — single numeric value (1 = pass, 0 = fail)
+- `/logs/verifier/reward.json` — JSON with `{"reward": float}` for fractional scores
 
 ### Comparing Frameworks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,6 +2964,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4474,6 +4475,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5428,6 +5442,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ reqwest = { version = "0.12", features = ["json"] }
 
 # Temp files (used for per-task in-memory workspace DBs)
 tempfile = "3"
+
+# YAML parsing (terminal bench legacy task format)
+serde_yaml = "0.9"

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -3,6 +3,7 @@ pub mod gaia;
 pub mod spot;
 pub mod swe_bench;
 pub mod tau_bench;
+pub mod terminal_bench;
 pub mod trajectory;
 
 use crate::config::BenchConfig;
@@ -16,6 +17,10 @@ pub const KNOWN_SUITES: &[(&str, &str)] = &[
     ("spot", "Spot checks (end-to-end user workflows)"),
     ("tau_bench", "Tau-bench (multi-turn tool use)"),
     ("swe_bench", "SWE-bench Pro (software engineering)"),
+    (
+        "terminal_bench",
+        "Terminal Bench (containerized terminal tasks)",
+    ),
     ("trajectory", "Multi-turn trajectory scenarios"),
 ];
 
@@ -109,6 +114,32 @@ pub fn create_suite(name: &str, config: &BenchConfig) -> Result<Box<dyn BenchSui
                 dataset_path,
                 workspace_dir,
                 use_docker,
+            )))
+        }
+        "terminal_bench" => {
+            let dataset_path = suite_map
+                .get("dataset_path")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    BenchError::Config(
+                        "suite_config.dataset_path is required for 'terminal_bench' suite"
+                            .to_string(),
+                    )
+                })?;
+            let rebuild_images = suite_map
+                .get("rebuild_images")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let verifier_timeout = suite_map
+                .get("verifier_timeout")
+                .and_then(|v| v.as_str())
+                .and_then(|s| crate::config::parse_duration(s).ok())
+                .unwrap_or(std::time::Duration::from_secs(300));
+            Ok(Box::new(terminal_bench::TerminalBenchSuite::new(
+                dataset_path,
+                rebuild_images,
+                verifier_timeout,
             )))
         }
         "trajectory" => {

--- a/src/adapters/terminal_bench.rs
+++ b/src/adapters/terminal_bench.rs
@@ -1,0 +1,958 @@
+//! Terminal Bench adapter — containerized terminal task evaluation.
+//!
+//! Each task runs inside its own Docker container. The agent interacts via
+//! shell commands (routed through `docker exec`), then a test script verifies
+//! success by writing a reward file.
+//!
+//! Supports both Harbor/TB2 format (`task.toml` + `instruction.md`) and legacy
+//! Terminal Bench format (`task.yaml` with inline instruction).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use ironclaw::context::JobContext;
+use ironclaw::tools::{Tool, ToolDomain, ToolError, ToolOutput};
+
+/// Extract a required string parameter from a JSON object.
+fn require_str<'a>(params: &'a serde_json::Value, name: &str) -> Result<&'a str, ToolError> {
+    params
+        .get(name)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolError::InvalidParameters(format!("missing '{name}' parameter")))
+}
+
+use crate::docker;
+use crate::error::BenchError;
+use crate::suite::{BenchScore, BenchSuite, BenchTask, TaskSubmission};
+
+// ---------------------------------------------------------------------------
+// Task config parsing (Harbor/TB2 format)
+// ---------------------------------------------------------------------------
+
+/// Parsed from `task.toml` (Harbor/TB2 format).
+#[derive(Debug, Deserialize)]
+struct TbTaskToml {
+    #[serde(default)]
+    task: TbTaskSection,
+    #[serde(default)]
+    metadata: TbMetadata,
+    #[serde(default)]
+    agent: TbAgentConfig,
+    #[serde(default)]
+    verifier: TbVerifierConfig,
+    #[serde(default)]
+    environment: TbEnvironment,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TbTaskSection {
+    #[serde(default)]
+    #[allow(dead_code)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TbMetadata {
+    #[serde(default)]
+    difficulty: Option<String>,
+    #[serde(default)]
+    category: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TbAgentConfig {
+    #[serde(default = "default_agent_timeout")]
+    timeout_sec: f64,
+}
+
+impl Default for TbAgentConfig {
+    fn default() -> Self {
+        Self {
+            timeout_sec: default_agent_timeout(),
+        }
+    }
+}
+
+fn default_agent_timeout() -> f64 {
+    600.0
+}
+
+#[derive(Debug, Deserialize)]
+struct TbVerifierConfig {
+    #[serde(default = "default_verifier_timeout")]
+    timeout_sec: f64,
+}
+
+impl Default for TbVerifierConfig {
+    fn default() -> Self {
+        Self {
+            timeout_sec: default_verifier_timeout(),
+        }
+    }
+}
+
+fn default_verifier_timeout() -> f64 {
+    600.0
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct TbEnvironment {
+    #[serde(default)]
+    cpus: Option<f64>,
+    #[serde(default)]
+    memory_mb: Option<u64>,
+}
+
+/// Parsed from `task.yaml` (legacy Terminal Bench format).
+#[derive(Debug, Deserialize)]
+struct TbTaskYaml {
+    instruction: String,
+    #[serde(default)]
+    difficulty: Option<String>,
+    #[serde(default)]
+    category: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default = "default_agent_timeout")]
+    max_agent_timeout_sec: f64,
+    #[serde(default = "default_verifier_timeout")]
+    max_test_timeout_sec: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Per-task runtime state stored in metadata
+// ---------------------------------------------------------------------------
+
+/// Metadata stored on BenchTask.metadata for runtime use.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct TbTaskMeta {
+    task_dir: String,
+    verifier_timeout_sec: f64,
+    #[serde(default)]
+    cpus: Option<f64>,
+    #[serde(default)]
+    memory_mb: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// DockerExecTool — routes shell commands into the task container
+// ---------------------------------------------------------------------------
+
+/// A tool that executes shell commands inside a Docker container.
+///
+/// Named `"shell"` so the agent uses it naturally. Looks up the container ID
+/// from the shared map using the task ID extracted from `JobContext.title`.
+pub struct DockerExecTool {
+    containers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+    timeout: Duration,
+}
+
+#[async_trait]
+impl Tool for DockerExecTool {
+    fn name(&self) -> &str {
+        "shell"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a shell command. The command runs inside an isolated container environment."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute"
+                }
+            },
+            "required": ["command"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let command = require_str(&params, "command")?;
+        let task_id = extract_task_id(&ctx.title);
+
+        let container_id = {
+            let map = self.containers.lock().await;
+            map.get(task_id).cloned().ok_or_else(|| {
+                ToolError::ExecutionFailed(format!("no container for task '{task_id}'"))
+            })?
+        };
+
+        let start = std::time::Instant::now();
+        let result = docker::exec_in_container(&container_id, command, self.timeout).await;
+
+        match result {
+            Ok(output) => {
+                let duration = start.elapsed();
+                let text = if output.stderr.is_empty() {
+                    output.stdout
+                } else if output.stdout.is_empty() {
+                    output.stderr
+                } else {
+                    format!("{}\n{}", output.stdout, output.stderr)
+                };
+                let mut tool_output = ToolOutput::text(text, duration);
+                if output.exit_code != 0 {
+                    tool_output.raw = Some(format!("exit code: {}", output.exit_code));
+                }
+                Ok(tool_output)
+            }
+            Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+        }
+    }
+
+    fn requires_approval(&self) -> bool {
+        false
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Container
+    }
+
+    fn execution_timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+}
+
+/// DockerReadFileTool — reads files from inside the task container.
+pub struct DockerReadFileTool {
+    containers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+}
+
+#[async_trait]
+impl Tool for DockerReadFileTool {
+    fn name(&self) -> &str {
+        "read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read the contents of a file at the given path."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file to read"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let path = require_str(&params, "path")?;
+        let task_id = extract_task_id(&ctx.title);
+
+        let container_id = {
+            let map = self.containers.lock().await;
+            map.get(task_id).cloned().ok_or_else(|| {
+                ToolError::ExecutionFailed(format!("no container for task '{task_id}'"))
+            })?
+        };
+
+        let start = std::time::Instant::now();
+        let cmd = format!("cat {}", shell_escape(path));
+        match docker::exec_in_container(&container_id, &cmd, Duration::from_secs(30)).await {
+            Ok(output) if output.exit_code == 0 => {
+                Ok(ToolOutput::text(output.stdout, start.elapsed()))
+            }
+            Ok(output) => Err(ToolError::ExecutionFailed(format!(
+                "failed to read {path}: {}",
+                output.stderr
+            ))),
+            Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+        }
+    }
+
+    fn requires_approval(&self) -> bool {
+        false
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Container
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+}
+
+/// DockerWriteFileTool — writes files inside the task container.
+pub struct DockerWriteFileTool {
+    containers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+}
+
+#[async_trait]
+impl Tool for DockerWriteFileTool {
+    fn name(&self) -> &str {
+        "write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write content to a file at the given path, creating it if it doesn't exist."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to write the file"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file"
+                }
+            },
+            "required": ["path", "content"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let path = require_str(&params, "path")?;
+        let content = require_str(&params, "content")?;
+        let task_id = extract_task_id(&ctx.title);
+
+        let container_id = {
+            let map = self.containers.lock().await;
+            map.get(task_id).cloned().ok_or_else(|| {
+                ToolError::ExecutionFailed(format!("no container for task '{task_id}'"))
+            })?
+        };
+
+        let start = std::time::Instant::now();
+        // Use heredoc to avoid quoting issues
+        let cmd = format!(
+            "mkdir -p $(dirname {path_escaped}) && cat > {path_escaped} << 'TBEOF'\n{content}\nTBEOF",
+            path_escaped = shell_escape(path),
+            content = content,
+        );
+        match docker::exec_in_container(&container_id, &cmd, Duration::from_secs(30)).await {
+            Ok(output) if output.exit_code == 0 => {
+                Ok(ToolOutput::text(format!("wrote {path}"), start.elapsed()))
+            }
+            Ok(output) => Err(ToolError::ExecutionFailed(format!(
+                "failed to write {path}: {}",
+                output.stderr
+            ))),
+            Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+        }
+    }
+
+    fn requires_approval(&self) -> bool {
+        false
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Container
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TerminalBenchSuite
+// ---------------------------------------------------------------------------
+
+pub struct TerminalBenchSuite {
+    dataset_path: PathBuf,
+    rebuild_images: bool,
+    verifier_timeout: Duration,
+    /// task_id -> container_id (shared with DockerExecTool instances)
+    containers: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
+    /// task_id -> reward value (populated in teardown, read in score)
+    rewards: Arc<tokio::sync::Mutex<HashMap<String, f64>>>,
+}
+
+impl TerminalBenchSuite {
+    pub fn new(
+        dataset_path: impl Into<PathBuf>,
+        rebuild_images: bool,
+        verifier_timeout: Duration,
+    ) -> Self {
+        Self {
+            dataset_path: dataset_path.into(),
+            rebuild_images,
+            verifier_timeout,
+            containers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            rewards: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl BenchSuite for TerminalBenchSuite {
+    fn name(&self) -> &str {
+        "Terminal Bench"
+    }
+
+    fn id(&self) -> &str {
+        "terminal_bench"
+    }
+
+    async fn load_tasks(&self) -> Result<Vec<BenchTask>, BenchError> {
+        let mut tasks = Vec::new();
+        discover_tasks(&self.dataset_path, &self.dataset_path, &mut tasks)?;
+        if tasks.is_empty() {
+            return Err(BenchError::Config(format!(
+                "no Terminal Bench tasks found in {}",
+                self.dataset_path.display()
+            )));
+        }
+        tracing::info!("Loaded {} Terminal Bench tasks", tasks.len());
+        Ok(tasks)
+    }
+
+    async fn setup_task(&self, task: &BenchTask) -> Result<(), BenchError> {
+        let meta: TbTaskMeta = serde_json::from_value(task.metadata.clone()).map_err(|e| {
+            BenchError::Config(format!(
+                "invalid terminal_bench metadata for {}: {e}",
+                task.id
+            ))
+        })?;
+
+        let task_dir = PathBuf::from(&meta.task_dir);
+
+        // Resolve Dockerfile: prefer environment/Dockerfile, fall back to task root
+        let dockerfile = if task_dir.join("environment/Dockerfile").exists() {
+            task_dir.join("environment/Dockerfile")
+        } else if task_dir.join("Dockerfile").exists() {
+            task_dir.join("Dockerfile")
+        } else {
+            return Err(BenchError::Docker(format!(
+                "no Dockerfile found for task {}",
+                task.id
+            )));
+        };
+
+        // Build context is the task directory (or environment/ if Dockerfile is there)
+        let build_context = if task_dir.join("environment/Dockerfile").exists() {
+            task_dir.join("environment")
+        } else {
+            task_dir.clone()
+        };
+
+        let image_tag = format!("tb-{}", sanitize_for_docker(&task.id));
+        docker::build_image(&image_tag, &dockerfile, &build_context, self.rebuild_images).await?;
+
+        let container_name = format!("tb-{}-{}", sanitize_for_docker(&task.id), short_uuid());
+
+        let container_id = docker::start_container(
+            &image_tag,
+            &container_name,
+            meta.cpus,
+            meta.memory_mb,
+            &[],
+            &[],
+        )
+        .await?;
+
+        // Create /logs/verifier/ inside the container for reward files
+        docker::exec_in_container(
+            &container_id,
+            "mkdir -p /logs/verifier /logs/agent",
+            Duration::from_secs(10),
+        )
+        .await?;
+
+        // Copy test files into the container if they exist
+        let tests_dir = task_dir.join("tests");
+        if tests_dir.exists() {
+            copy_dir_to_container(&container_id, &tests_dir, "/tests").await?;
+        }
+
+        // Copy test.sh / run-tests.sh if at task root
+        let test_sh = task_dir.join("test.sh");
+        if test_sh.exists() {
+            copy_file_to_container(&container_id, &test_sh, "/tests/test.sh").await?;
+        }
+        let run_tests_sh = task_dir.join("run-tests.sh");
+        if run_tests_sh.exists() {
+            copy_file_to_container(&container_id, &run_tests_sh, "/tests/run-tests.sh").await?;
+        }
+
+        // Copy solution if present (for oracle runs)
+        let solution_dir = task_dir.join("solution");
+        if solution_dir.exists() {
+            copy_dir_to_container(&container_id, &solution_dir, "/solution").await?;
+        }
+
+        self.containers
+            .lock()
+            .await
+            .insert(task.id.clone(), container_id);
+
+        Ok(())
+    }
+
+    async fn teardown_task(&self, task: &BenchTask) -> Result<(), BenchError> {
+        let container_id = {
+            let mut map = self.containers.lock().await;
+            match map.remove(&task.id) {
+                Some(id) => id,
+                None => {
+                    tracing::warn!("no container found for task {} during teardown", task.id);
+                    return Ok(());
+                }
+            }
+        };
+
+        // Run the test/verifier script inside the container
+        let reward = run_verifier(&container_id, self.verifier_timeout).await;
+
+        // Cache the reward for score()
+        self.rewards.lock().await.insert(task.id.clone(), reward);
+
+        // Clean up the container
+        docker::stop_and_remove(&container_id).await?;
+
+        Ok(())
+    }
+
+    async fn score(
+        &self,
+        task: &BenchTask,
+        _submission: &TaskSubmission,
+    ) -> Result<BenchScore, BenchError> {
+        let reward = self.rewards.lock().await.remove(&task.id).unwrap_or(0.0);
+
+        if reward >= 1.0 {
+            Ok(BenchScore::pass())
+        } else if reward <= 0.0 {
+            Ok(BenchScore::fail("task not solved"))
+        } else {
+            Ok(BenchScore::partial(reward, format!("reward: {reward:.2}")))
+        }
+    }
+
+    fn additional_tools(&self) -> Vec<Arc<dyn Tool>> {
+        vec![
+            Arc::new(DockerExecTool {
+                containers: Arc::clone(&self.containers),
+                timeout: Duration::from_secs(120),
+            }),
+            Arc::new(DockerReadFileTool {
+                containers: Arc::clone(&self.containers),
+            }),
+            Arc::new(DockerWriteFileTool {
+                containers: Arc::clone(&self.containers),
+            }),
+        ]
+    }
+
+    async fn openclaw_task_metadata(
+        &self,
+        task: &BenchTask,
+    ) -> Option<serde_json::Map<String, serde_json::Value>> {
+        let containers = self.containers.lock().await;
+        let container_id = containers.get(&task.id)?;
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "tb_container_id".to_string(),
+            serde_json::Value::String(container_id.clone()),
+        );
+        Some(map)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task discovery
+// ---------------------------------------------------------------------------
+
+/// Recursively walk `dir` looking for task definitions.
+fn discover_tasks(root: &Path, dir: &Path, tasks: &mut Vec<BenchTask>) -> Result<(), BenchError> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        BenchError::Config(format!("failed to read directory {}: {e}", dir.display()))
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(BenchError::Io)?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            // Check for task.toml (Harbor/TB2 format)
+            if path.join("task.toml").exists() {
+                match load_tb2_task(root, &path) {
+                    Ok(task) => tasks.push(task),
+                    Err(e) => tracing::warn!("Skipping task at {}: {e}", path.display()),
+                }
+            }
+            // Check for task.yaml (legacy format)
+            else if path.join("task.yaml").exists() {
+                match load_legacy_task(root, &path) {
+                    Ok(task) => tasks.push(task),
+                    Err(e) => tracing::warn!("Skipping task at {}: {e}", path.display()),
+                }
+            }
+            // Otherwise recurse
+            else {
+                discover_tasks(root, &path, tasks)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Load a task from Harbor/TB2 format (task.toml + instruction.md).
+fn load_tb2_task(root: &Path, task_dir: &Path) -> Result<BenchTask, BenchError> {
+    let toml_path = task_dir.join("task.toml");
+    let toml_str = std::fs::read_to_string(&toml_path).map_err(BenchError::Io)?;
+    let config: TbTaskToml = toml::from_str(&toml_str).map_err(BenchError::Toml)?;
+
+    let instruction = if task_dir.join("instruction.md").exists() {
+        std::fs::read_to_string(task_dir.join("instruction.md")).map_err(BenchError::Io)?
+    } else {
+        config
+            .task
+            .description
+            .clone()
+            .unwrap_or_else(|| "No instruction provided".to_string())
+    };
+
+    let task_id = derive_task_id(root, task_dir);
+
+    let mut tags = config.metadata.tags.clone();
+    if let Some(ref diff) = config.metadata.difficulty {
+        tags.push(format!("difficulty:{diff}"));
+    }
+    if let Some(ref cat) = config.metadata.category {
+        tags.push(format!("category:{cat}"));
+    }
+
+    let meta = TbTaskMeta {
+        task_dir: task_dir.to_string_lossy().to_string(),
+        verifier_timeout_sec: config.verifier.timeout_sec,
+        cpus: config.environment.cpus,
+        memory_mb: config.environment.memory_mb,
+    };
+
+    Ok(BenchTask {
+        id: task_id,
+        prompt: instruction,
+        context: None,
+        resources: vec![],
+        tags,
+        expected_turns: None,
+        timeout: Some(Duration::from_secs_f64(config.agent.timeout_sec)),
+        metadata: serde_json::to_value(meta).map_err(BenchError::Json)?,
+    })
+}
+
+/// Load a task from legacy Terminal Bench format (task.yaml).
+fn load_legacy_task(root: &Path, task_dir: &Path) -> Result<BenchTask, BenchError> {
+    let yaml_path = task_dir.join("task.yaml");
+    let yaml_str = std::fs::read_to_string(&yaml_path).map_err(BenchError::Io)?;
+    let config: TbTaskYaml = serde_yaml::from_str(&yaml_str)
+        .map_err(|e| BenchError::Config(format!("failed to parse {}: {e}", yaml_path.display())))?;
+
+    let task_id = derive_task_id(root, task_dir);
+
+    let mut tags = config.tags.clone();
+    if let Some(ref diff) = config.difficulty {
+        tags.push(format!("difficulty:{diff}"));
+    }
+    if let Some(ref cat) = config.category {
+        tags.push(format!("category:{cat}"));
+    }
+
+    let meta = TbTaskMeta {
+        task_dir: task_dir.to_string_lossy().to_string(),
+        verifier_timeout_sec: config.max_test_timeout_sec,
+        cpus: None,
+        memory_mb: None,
+    };
+
+    Ok(BenchTask {
+        id: task_id,
+        prompt: config.instruction,
+        context: None,
+        resources: vec![],
+        tags,
+        expected_turns: None,
+        timeout: Some(Duration::from_secs_f64(config.max_agent_timeout_sec)),
+        metadata: serde_json::to_value(meta).map_err(BenchError::Json)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Verifier / reward parsing
+// ---------------------------------------------------------------------------
+
+/// Run the verifier (test script) inside the container and return the reward.
+async fn run_verifier(container_id: &str, timeout: Duration) -> f64 {
+    // Try test.sh first, then run-tests.sh
+    let test_script = if docker::exec_in_container(
+        container_id,
+        "test -f /tests/test.sh",
+        Duration::from_secs(5),
+    )
+    .await
+    .map(|o| o.exit_code == 0)
+    .unwrap_or(false)
+    {
+        "bash /tests/test.sh"
+    } else if docker::exec_in_container(
+        container_id,
+        "test -f /tests/run-tests.sh",
+        Duration::from_secs(5),
+    )
+    .await
+    .map(|o| o.exit_code == 0)
+    .unwrap_or(false)
+    {
+        "bash /tests/run-tests.sh"
+    } else {
+        tracing::warn!("no test script found in container {container_id}");
+        return 0.0;
+    };
+
+    tracing::info!("Running verifier: {test_script}");
+    match docker::exec_in_container(container_id, test_script, timeout).await {
+        Ok(output) => {
+            if !output.stderr.is_empty() {
+                tracing::debug!("verifier stderr: {}", output.stderr.trim());
+            }
+        }
+        Err(e) => {
+            tracing::warn!("verifier execution failed: {e}");
+            return 0.0;
+        }
+    }
+
+    // Read reward.txt first, fall back to reward.json
+    if let Ok(output) = docker::exec_in_container(
+        container_id,
+        "cat /logs/verifier/reward.txt",
+        Duration::from_secs(5),
+    )
+    .await
+    {
+        if output.exit_code == 0 {
+            if let Ok(reward) = output.stdout.trim().parse::<f64>() {
+                return reward;
+            }
+        }
+    }
+
+    if let Ok(output) = docker::exec_in_container(
+        container_id,
+        "cat /logs/verifier/reward.json",
+        Duration::from_secs(5),
+    )
+    .await
+    {
+        if output.exit_code == 0 {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(output.stdout.trim()) {
+                // Support both {"reward": 1.0} and plain numeric values
+                if let Some(r) = json.get("reward").and_then(|v| v.as_f64()) {
+                    return r;
+                }
+                if let Some(r) = json.as_f64() {
+                    return r;
+                }
+            }
+        }
+    }
+
+    tracing::warn!("no reward file found in container {container_id}");
+    0.0
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Derive a task ID from the relative path under the dataset root.
+fn derive_task_id(root: &Path, task_dir: &Path) -> String {
+    task_dir
+        .strip_prefix(root)
+        .unwrap_or(task_dir)
+        .to_string_lossy()
+        .replace(['/', '\\'], "-")
+        .trim_matches('-')
+        .to_string()
+}
+
+/// Extract the task ID from a `JobContext.title` like `"bench-{task_id}"`.
+fn extract_task_id(title: &str) -> &str {
+    title.strip_prefix("bench-").unwrap_or(title)
+}
+
+/// Sanitize a string for use as a Docker image/container name.
+fn sanitize_for_docker(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .to_lowercase()
+}
+
+/// Generate a short UUID suffix for container names.
+fn short_uuid() -> String {
+    Uuid::new_v4().to_string()[..8].to_string()
+}
+
+/// Basic shell escaping — wraps in single quotes.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Copy a local file into a container.
+async fn copy_file_to_container(
+    container_id: &str,
+    local_path: &Path,
+    container_path: &str,
+) -> Result<(), BenchError> {
+    // Ensure parent directory exists
+    if let Some(parent) = Path::new(container_path).parent() {
+        docker::exec_in_container(
+            container_id,
+            &format!("mkdir -p {}", parent.display()),
+            Duration::from_secs(10),
+        )
+        .await?;
+    }
+
+    let output = tokio::process::Command::new("docker")
+        .args([
+            "cp",
+            &local_path.to_string_lossy(),
+            &format!("{container_id}:{container_path}"),
+        ])
+        .output()
+        .await
+        .map_err(|e| BenchError::Docker(format!("docker cp failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BenchError::Docker(format!("docker cp failed: {stderr}")));
+    }
+    Ok(())
+}
+
+/// Copy a local directory into a container.
+async fn copy_dir_to_container(
+    container_id: &str,
+    local_dir: &Path,
+    container_path: &str,
+) -> Result<(), BenchError> {
+    docker::exec_in_container(
+        container_id,
+        &format!("mkdir -p {container_path}"),
+        Duration::from_secs(10),
+    )
+    .await?;
+
+    // docker cp src/. container:dest copies contents of src into dest
+    let src = format!("{}/.", &local_dir.to_string_lossy());
+    let output = tokio::process::Command::new("docker")
+        .args(["cp", &src, &format!("{container_id}:{container_path}")])
+        .output()
+        .await
+        .map_err(|e| BenchError::Docker(format!("docker cp failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!("docker cp dir failed: {stderr}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_task_id() {
+        let root = Path::new("/data/terminal-bench/tasks");
+        let task_dir = Path::new("/data/terminal-bench/tasks/hello-world");
+        assert_eq!(derive_task_id(root, task_dir), "hello-world");
+
+        let nested = Path::new("/data/terminal-bench/tasks/category/my-task");
+        assert_eq!(derive_task_id(root, nested), "category-my-task");
+    }
+
+    #[test]
+    fn test_extract_task_id() {
+        assert_eq!(extract_task_id("bench-hello-world"), "hello-world");
+        assert_eq!(
+            extract_task_id("bench-category-my-task"),
+            "category-my-task"
+        );
+        assert_eq!(extract_task_id("no-prefix"), "no-prefix");
+    }
+
+    #[test]
+    fn test_sanitize_for_docker() {
+        assert_eq!(sanitize_for_docker("hello-world"), "hello-world");
+        assert_eq!(sanitize_for_docker("My/Task_v2"), "my-task-v2");
+    }
+
+    #[test]
+    fn test_parse_tb2_toml() {
+        let toml_str = r#"
+[task]
+name = "test/hello"
+
+[metadata]
+difficulty = "easy"
+tags = ["basic"]
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 60.0
+
+[environment]
+cpus = 2.0
+memory_mb = 4096
+"#;
+        let config: TbTaskToml = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.agent.timeout_sec, 300.0);
+        assert_eq!(config.verifier.timeout_sec, 60.0);
+        assert_eq!(config.environment.cpus, Some(2.0));
+        assert_eq!(config.metadata.tags, vec!["basic"]);
+    }
+}

--- a/src/adapters/trajectory.rs
+++ b/src/adapters/trajectory.rs
@@ -258,18 +258,18 @@ impl TrajectorySuite {
             if turn.user_input.is_empty() {
                 if let Some(ref file) = turn.user_input_file {
                     let file_path = base_dir.join(file);
-                    turn.user_input =
-                        std::fs::read_to_string(&file_path).map_err(|e| {
-                            BenchError::Config(format!(
-                                "failed to read user_input_file {}: {}",
-                                file_path.display(),
-                                e
-                            ))
-                        })?;
+                    turn.user_input = std::fs::read_to_string(&file_path).map_err(|e| {
+                        BenchError::Config(format!(
+                            "failed to read user_input_file {}: {}",
+                            file_path.display(),
+                            e
+                        ))
+                    })?;
                 } else {
                     return Err(BenchError::Config(format!(
                         "turn {} in {} has neither user_input nor user_input_file",
-                        i, path.display()
+                        i,
+                        path.display()
                     )));
                 }
             }
@@ -741,7 +741,11 @@ mod tests {
     async fn test_user_input_file() {
         let dir = tempfile::tempdir().unwrap();
 
-        std::fs::write(dir.path().join("prompt.md"), "What is the capital of France?").unwrap();
+        std::fs::write(
+            dir.path().join("prompt.md"),
+            "What is the capital of France?",
+        )
+        .unwrap();
 
         let path = dir.path().join("test.json");
         let mut file = std::fs::File::create(&path).unwrap();
@@ -809,19 +813,20 @@ mod tests {
         )
         .unwrap();
 
-        let suite = TrajectorySuite::new(
-            scenario_dir.path(),
-            Some(ws_dir.path().to_path_buf()),
-        );
+        let suite = TrajectorySuite::new(scenario_dir.path(), Some(ws_dir.path().to_path_buf()));
         let tasks = suite.load_tasks().await.unwrap();
 
         // Extract merged identity from metadata
-        let identity: HashMap<String, String> = serde_json::from_value(
-            tasks[0].metadata["setup"]["identity"].clone(),
-        )
-        .unwrap();
+        let identity: HashMap<String, String> =
+            serde_json::from_value(tasks[0].metadata["setup"]["identity"].clone()).unwrap();
 
-        assert_eq!(identity["SOUL.md"], "Overridden soul.", "Scenario should override base");
-        assert_eq!(identity["IDENTITY.md"], "Base identity.", "Base should be preserved");
+        assert_eq!(
+            identity["SOUL.md"], "Overridden soul.",
+            "Scenario should override base"
+        );
+        assert_eq!(
+            identity["IDENTITY.md"], "Base identity.",
+            "Base should be preserved"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,7 +151,7 @@ where
     parse_duration(&s).map_err(serde::de::Error::custom)
 }
 
-fn parse_duration(s: &str) -> Result<Duration, String> {
+pub fn parse_duration(s: &str) -> Result<Duration, String> {
     let s = s.trim();
     if let Some(secs) = s.strip_suffix('s') {
         secs.trim()

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,0 +1,173 @@
+//! Shared Docker container management utilities.
+//!
+//! Provides helpers for building images, starting/stopping containers,
+//! and executing commands inside containers. Used by the Terminal Bench
+//! adapter and potentially other container-based suites.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use crate::error::BenchError;
+
+/// Output from executing a command inside a container.
+#[derive(Debug)]
+pub struct ExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Build a Docker image from a Dockerfile.
+///
+/// Skips the build if the image already exists and `force_rebuild` is false.
+pub async fn build_image(
+    tag: &str,
+    dockerfile: &std::path::Path,
+    context: &std::path::Path,
+    force_rebuild: bool,
+) -> Result<(), BenchError> {
+    if !force_rebuild && image_exists(tag).await {
+        tracing::debug!("Docker image {} already exists, skipping build", tag);
+        return Ok(());
+    }
+
+    tracing::info!("Building Docker image: {}", tag);
+    let output = tokio::process::Command::new("docker")
+        .args([
+            "build",
+            "-t",
+            tag,
+            "-f",
+            &dockerfile.to_string_lossy(),
+            &context.to_string_lossy(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| BenchError::Docker(format!("failed to run docker build: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BenchError::Docker(format!(
+            "docker build failed for {tag}: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Start a Docker container and return its container ID.
+pub async fn start_container(
+    image: &str,
+    name: &str,
+    cpus: Option<f64>,
+    memory_mb: Option<u64>,
+    env_vars: &[(String, String)],
+    volumes: &[(String, String)],
+) -> Result<String, BenchError> {
+    let mut args = vec![
+        "run".to_string(),
+        "-d".to_string(),
+        "--name".to_string(),
+        name.to_string(),
+    ];
+
+    if let Some(cpus) = cpus {
+        args.push(format!("--cpus={cpus}"));
+    }
+    if let Some(mem) = memory_mb {
+        args.push(format!("--memory={mem}m"));
+    }
+    for (key, val) in env_vars {
+        args.push("-e".to_string());
+        args.push(format!("{key}={val}"));
+    }
+    for (host, container) in volumes {
+        args.push("-v".to_string());
+        args.push(format!("{host}:{container}"));
+    }
+
+    args.push(image.to_string());
+    // Keep container alive with a long sleep
+    args.push("sleep".to_string());
+    args.push("infinity".to_string());
+
+    let output = tokio::process::Command::new("docker")
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| BenchError::Docker(format!("failed to run docker run: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BenchError::Docker(format!(
+            "docker run failed for {name}: {stderr}"
+        )));
+    }
+
+    let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    tracing::info!("Started container {} ({})", name, &container_id[..12]);
+    Ok(container_id)
+}
+
+/// Execute a command inside a running container.
+pub async fn exec_in_container(
+    container_id: &str,
+    command: &str,
+    timeout: Duration,
+) -> Result<ExecOutput, BenchError> {
+    let result = tokio::time::timeout(
+        timeout,
+        tokio::process::Command::new("docker")
+            .args(["exec", container_id, "bash", "-c", command])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) => Ok(ExecOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: output.status.code().unwrap_or(-1),
+        }),
+        Ok(Err(e)) => Err(BenchError::Docker(format!("docker exec failed: {e}"))),
+        Err(_) => Err(BenchError::Docker(format!(
+            "docker exec timed out after {timeout:?}"
+        ))),
+    }
+}
+
+/// Stop and remove a container.
+pub async fn stop_and_remove(container_id: &str) -> Result<(), BenchError> {
+    let output = tokio::process::Command::new("docker")
+        .args(["rm", "-f", container_id])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| BenchError::Docker(format!("docker rm -f failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!("docker rm -f {} failed: {}", container_id, stderr);
+    }
+
+    Ok(())
+}
+
+/// Check if a Docker image exists locally.
+async fn image_exists(tag: &str) -> bool {
+    tokio::process::Command::new("docker")
+        .args(["image", "inspect", tag])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,4 +31,7 @@ pub enum BenchError {
 
     #[error("OpenClaw error: {0}")]
     OpenClaw(String),
+
+    #[error("Docker error: {0}")]
+    Docker(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod adapters;
 mod channel;
 mod config;
+mod docker;
 mod error;
 mod instrumented_llm;
 mod openclaw;
@@ -204,12 +205,11 @@ async fn main() -> anyhow::Result<()> {
                     )
                 })?;
 
-                let session =
-                    ironclaw::llm::create_session_manager(ironclaw::llm::SessionConfig {
-                        auth_base_url: ironclaw_config.llm.nearai.auth_base_url.clone(),
-                        session_path: ironclaw_config.llm.nearai.session_path.clone(),
-                    })
-                    .await;
+                let session = ironclaw::llm::create_session_manager(ironclaw::llm::SessionConfig {
+                    auth_base_url: ironclaw_config.llm.nearai.auth_base_url.clone(),
+                    session_path: ironclaw_config.llm.nearai.session_path.clone(),
+                })
+                .await;
 
                 let is_nearai = matches!(
                     ironclaw_config.llm.backend,
@@ -220,13 +220,11 @@ async fn main() -> anyhow::Result<()> {
                 }
 
                 let llm = ironclaw::llm::create_llm_provider(&ironclaw_config.llm, session)?;
-                let safety =
-                    Arc::new(ironclaw::safety::SafetyLayer::new(&ironclaw_config.safety));
+                let safety = Arc::new(ironclaw::safety::SafetyLayer::new(&ironclaw_config.safety));
                 runner::FrameworkDeps::Ironclaw { llm, safety }
             };
 
-            let runner =
-                runner::BenchRunner::new(bench_suite, bench_config.clone(), framework);
+            let runner = runner::BenchRunner::new(bench_suite, bench_config.clone(), framework);
 
             // Run for each matrix entry
             for matrix_entry in &bench_config.matrix {

--- a/src/openclaw.rs
+++ b/src/openclaw.rs
@@ -92,8 +92,11 @@ impl OpenClawRunner {
         }
 
         let config_path = config_dir.path().join("openclaw.json");
-        std::fs::write(&config_path, serde_json::to_string_pretty(&oc_config).unwrap())
-            .map_err(|e| BenchError::OpenClaw(format!("failed to write openclaw.json: {e}")))?;
+        std::fs::write(
+            &config_path,
+            serde_json::to_string_pretty(&oc_config).unwrap(),
+        )
+        .map_err(|e| BenchError::OpenClaw(format!("failed to write openclaw.json: {e}")))?;
 
         let agent_dir = config_dir.path().join("agents/main/agent");
         std::fs::create_dir_all(&agent_dir)
@@ -127,8 +130,11 @@ impl OpenClawRunner {
             "profiles": profiles
         });
         let auth_path = agent_dir.join("auth-profiles.json");
-        std::fs::write(&auth_path, serde_json::to_string_pretty(&auth_store).unwrap())
-            .map_err(|e| BenchError::OpenClaw(format!("failed to write auth-profiles.json: {e}")))?;
+        std::fs::write(
+            &auth_path,
+            serde_json::to_string_pretty(&auth_store).unwrap(),
+        )
+        .map_err(|e| BenchError::OpenClaw(format!("failed to write auth-profiles.json: {e}")))?;
 
         let forwarded_env_vars = [
             "OPENAI_API_KEY",
@@ -161,6 +167,19 @@ impl OpenClawRunner {
             }
         }
 
+        // If this is a Terminal Bench task, mount the Docker socket so the
+        // openclaw agent can exec commands in the TB task container.
+        if let Some(tb_id) = task
+            .metadata
+            .get("tb_container_id")
+            .and_then(|v| v.as_str())
+        {
+            docker_args.push("-v".to_string());
+            docker_args.push("/var/run/docker.sock:/var/run/docker.sock".to_string());
+            docker_args.push("-e".to_string());
+            docker_args.push(format!("TB_CONTAINER_ID={tb_id}"));
+        }
+
         docker_args.extend([
             self.image.clone(),
             "node".to_string(),
@@ -180,9 +199,7 @@ impl OpenClawRunner {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(BenchError::OpenClaw(format!(
-                "docker run failed: {stderr}"
-            )));
+            return Err(BenchError::OpenClaw(format!("docker run failed: {stderr}")));
         }
 
         let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -219,7 +236,12 @@ impl OpenClawRunner {
             }
 
             let inspect = Command::new("docker")
-                .args(["inspect", "--format", "{{.State.Running}}", &handle.container_id])
+                .args([
+                    "inspect",
+                    "--format",
+                    "{{.State.Running}}",
+                    &handle.container_id,
+                ])
                 .output();
             if let Ok(out) = inspect {
                 let state = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -257,10 +279,7 @@ impl OpenClawRunner {
         prompt: &str,
         timeout: Duration,
     ) -> Result<OpenClawResponse, BenchError> {
-        let url = format!(
-            "http://127.0.0.1:{}/v1/chat/completions",
-            handle.port
-        );
+        let url = format!("http://127.0.0.1:{}/v1/chat/completions", handle.port);
 
         let mut body = serde_json::json!({
             "messages": [{"role": "user", "content": prompt}],
@@ -318,6 +337,11 @@ pub struct OpenClawResponse {
 }
 
 /// Run a single task against an OpenClaw container.
+///
+/// If the task has `tb_container_id` in its metadata (set by the Terminal Bench
+/// adapter), the openclaw container is started with the Docker socket mounted
+/// and the prompt is prepended with instructions to use `docker exec` targeting
+/// the Terminal Bench task container.
 pub async fn run_task_openclaw(
     task: &BenchTask,
     suite_id: &str,
@@ -335,11 +359,7 @@ pub async fn run_task_openclaw(
         }
     };
 
-    let full_prompt = if let Some(ref ctx) = task.context {
-        format!("{}\n\nContext:\n{}", task.prompt, ctx)
-    } else {
-        task.prompt.clone()
-    };
+    let full_prompt = build_prompt(task);
 
     let result = match runner.chat_completion(&handle, &full_prompt, timeout).await {
         Ok(r) => r,
@@ -406,6 +426,31 @@ pub(crate) fn write_identity_files(
     Ok(written)
 }
 
+/// Build the prompt for a task, prepending TB container instructions if needed.
+fn build_prompt(task: &BenchTask) -> String {
+    let base = if let Some(ref ctx) = task.context {
+        format!("{}\n\nContext:\n{}", task.prompt, ctx)
+    } else {
+        task.prompt.clone()
+    };
+
+    if let Some(container_id) = task
+        .metadata
+        .get("tb_container_id")
+        .and_then(|v| v.as_str())
+    {
+        format!(
+            "IMPORTANT: You are working on a task inside a Docker container. \
+             To execute ANY shell commands, you MUST prefix them with:\n\
+             docker exec {container_id} <command>\n\n\
+             For example: docker exec {container_id} bash -c \"ls /tmp\"\n\n\
+             ---\n\n{base}"
+        )
+    } else {
+        base
+    }
+}
+
 /// Parse host port from `docker port` output like "0.0.0.0:32768" or ":::32768".
 fn parse_docker_port(output: &str) -> Option<u16> {
     output
@@ -424,10 +469,7 @@ mod tests {
     use super::*;
     use crate::suite::BenchTask;
 
-    fn make_task_with_identity(
-        id: &str,
-        identity: HashMap<String, String>,
-    ) -> BenchTask {
+    fn make_task_with_identity(id: &str, identity: HashMap<String, String>) -> BenchTask {
         let setup = serde_json::json!({ "identity": identity });
         BenchTask {
             id: id.to_string(),
@@ -473,8 +515,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut identity = HashMap::new();
         identity.insert("SOUL.md".to_string(), "Be helpful.".to_string());
-        identity.insert("IDENTITY.md".to_string(), "Name: ClawAssistant\nVersion: 2.4.1".to_string());
-        identity.insert("AGENTS.md".to_string(), "## Agent Config\n- Primary: chat-assistant".to_string());
+        identity.insert(
+            "IDENTITY.md".to_string(),
+            "Name: ClawAssistant\nVersion: 2.4.1".to_string(),
+        );
+        identity.insert(
+            "AGENTS.md".to_string(),
+            "## Agent Config\n- Primary: chat-assistant".to_string(),
+        );
 
         let written = write_identity_files(&identity, dir.path()).unwrap();
         assert_eq!(written.len(), 3);
@@ -541,7 +589,10 @@ mod tests {
             .and_then(|i| serde_json::from_value(i.clone()).ok())
             .unwrap_or_default();
 
-        assert_eq!(oc_identity, ic_identity, "Identity extraction must be identical across frameworks");
+        assert_eq!(
+            oc_identity, ic_identity,
+            "Identity extraction must be identical across frameworks"
+        );
         assert_eq!(oc_identity, identity);
     }
 
@@ -596,24 +647,39 @@ mod tests {
         };
 
         let task = zclaw_security_task();
-        let handle = runner.start_container(&task).await
+        let handle = runner
+            .start_container(&task)
+            .await
             .expect("Container should start successfully");
 
         // Verify container is running
         let output = Command::new("docker")
-            .args(["inspect", "--format", "{{.State.Running}}", &handle.container_id])
+            .args([
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
+                &handle.container_id,
+            ])
             .output()
             .unwrap();
         let running = String::from_utf8_lossy(&output.stdout).trim().to_string();
         assert_eq!(running, "true", "Container should be running");
 
         // Verify identity files are mounted in the workspace
-        let expected_files = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "TOOLS.md", "KNOWLEDGE.md"];
+        let expected_files = [
+            "SOUL.md",
+            "IDENTITY.md",
+            "AGENTS.md",
+            "TOOLS.md",
+            "KNOWLEDGE.md",
+        ];
         for filename in &expected_files {
             let output = Command::new("docker")
                 .args([
-                    "exec", &handle.container_id,
-                    "cat", &format!("/home/node/.openclaw/workspace/{filename}"),
+                    "exec",
+                    &handle.container_id,
+                    "cat",
+                    &format!("/home/node/.openclaw/workspace/{filename}"),
                 ])
                 .output()
                 .expect("docker exec should succeed");
@@ -622,27 +688,48 @@ mod tests {
                 "Failed to read {filename} from container"
             );
             let content = String::from_utf8_lossy(&output.stdout);
-            assert!(!content.is_empty(), "{filename} should not be empty in container");
+            assert!(
+                !content.is_empty(),
+                "{filename} should not be empty in container"
+            );
         }
 
         // Verify specific sensitive strings are present inside the container
         let identity_output = Command::new("docker")
             .args([
-                "exec", &handle.container_id,
-                "cat", "/home/node/.openclaw/workspace/IDENTITY.md",
+                "exec",
+                &handle.container_id,
+                "cat",
+                "/home/node/.openclaw/workspace/IDENTITY.md",
             ])
             .output()
             .unwrap();
         let identity_content = String::from_utf8_lossy(&identity_output.stdout);
-        assert!(identity_content.contains("ClawAssistant"), "IDENTITY.md should contain ClawAssistant");
-        assert!(identity_content.contains("openclaw-v2-72b"), "IDENTITY.md should contain model name");
-        assert!(identity_content.contains("production-cn-east"), "IDENTITY.md should contain deployment");
+        assert!(
+            identity_content.contains("ClawAssistant"),
+            "IDENTITY.md should contain ClawAssistant"
+        );
+        assert!(
+            identity_content.contains("openclaw-v2-72b"),
+            "IDENTITY.md should contain model name"
+        );
+        assert!(
+            identity_content.contains("production-cn-east"),
+            "IDENTITY.md should contain deployment"
+        );
 
         // Verify health endpoint responds
         let health_url = format!("http://127.0.0.1:{}/healthz", handle.port);
-        let resp = runner.http.get(&health_url).send().await
+        let resp = runner
+            .http
+            .get(&health_url)
+            .send()
+            .await
             .expect("Health check should succeed");
-        assert!(resp.status().is_success(), "Health endpoint should return 200");
+        assert!(
+            resp.status().is_success(),
+            "Health endpoint should return 200"
+        );
 
         // Container is cleaned up on drop
         let container_id = handle.container_id.clone();
@@ -654,7 +741,10 @@ mod tests {
             .args(["inspect", &container_id])
             .output()
             .unwrap();
-        assert!(!output.status.success(), "Container should be removed after drop");
+        assert!(
+            !output.status.success(),
+            "Container should be removed after drop"
+        );
     }
 
     #[tokio::test]
@@ -670,7 +760,9 @@ mod tests {
             || std::env::var("ANTHROPIC_API_KEY").is_ok()
             || std::env::var("OPENAI_API_KEY").is_ok();
         if !has_api_key {
-            eprintln!("Skipping: No API key found (need OPENROUTER_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY)");
+            eprintln!(
+                "Skipping: No API key found (need OPENROUTER_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY)"
+            );
             return;
         }
 
@@ -683,18 +775,27 @@ mod tests {
         };
 
         let task = zclaw_security_task();
-        let handle = runner.start_container(&task).await
+        let handle = runner
+            .start_container(&task)
+            .await
             .expect("Container should start");
 
         // Ask the agent a simple question — it should respond without errors
         let response = runner
-            .chat_completion(&handle, "What is 2+2? Reply with just the number.", Duration::from_secs(30))
+            .chat_completion(
+                &handle,
+                "What is 2+2? Reply with just the number.",
+                Duration::from_secs(30),
+            )
             .await
             .expect("Chat completion should succeed");
 
         assert!(!response.content.is_empty(), "Response should not be empty");
         assert!(response.prompt_tokens > 0, "Should report prompt tokens");
-        assert!(response.completion_tokens > 0, "Should report completion tokens");
+        assert!(
+            response.completion_tokens > 0,
+            "Should report completion tokens"
+        );
 
         // The prompt tokens should be >> the user message alone,
         // indicating the identity/system prompt was injected
@@ -717,10 +818,7 @@ mod tests {
 
     #[test]
     fn test_parse_docker_port_multiline() {
-        assert_eq!(
-            parse_docker_port("0.0.0.0:32768\n:::32768\n"),
-            Some(32768)
-        );
+        assert_eq!(parse_docker_port("0.0.0.0:32768\n:::32768\n"), Some(32768));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 use ironclaw::agent::{Agent, AgentDeps};
 use ironclaw::channels::{ChannelManager, IncomingMessage};
 use ironclaw::config::AgentConfig;
-use ironclaw::db::libsql::LibSqlBackend;
 use ironclaw::db::Database;
+use ironclaw::db::libsql::LibSqlBackend;
 use ironclaw::llm::LlmProvider;
 use ironclaw::safety::SafetyLayer;
 use ironclaw::tools::ToolRegistry;
@@ -57,11 +57,7 @@ pub struct BenchRunner {
 }
 
 impl BenchRunner {
-    pub fn new(
-        suite: Box<dyn BenchSuite>,
-        config: BenchConfig,
-        framework: FrameworkDeps,
-    ) -> Self {
+    pub fn new(suite: Box<dyn BenchSuite>, config: BenchConfig, framework: FrameworkDeps) -> Self {
         Self {
             suite: Arc::from(suite),
             config,
@@ -133,9 +129,10 @@ impl BenchRunner {
 
         let total_tasks = tasks.len() + completed.len();
         let openclaw_runner = if matches!(self.framework, FrameworkDeps::OpenClaw) {
-            Some(Arc::new(
-                crate::openclaw::OpenClawRunner::new(&self.config, matrix.model.clone())?,
-            ))
+            Some(Arc::new(crate::openclaw::OpenClawRunner::new(
+                &self.config,
+                matrix.model.clone(),
+            )?))
         } else {
             None
         };
@@ -197,8 +194,14 @@ impl BenchRunner {
                         run_task_isolated(params).await
                     }
                     FrameworkDeps::OpenClaw => {
+                        let mut oc_task = task.clone();
+                        if let Some(extra) = self.suite.openclaw_task_metadata(task).await {
+                            if let Some(map) = oc_task.metadata.as_object_mut() {
+                                map.extend(extra);
+                            }
+                        }
                         crate::openclaw::run_task_openclaw(
-                            task,
+                            &oc_task,
                             self.suite.id(),
                             &matrix.label,
                             timeout,
@@ -273,8 +276,14 @@ impl BenchRunner {
                             run_task_isolated(params).await
                         }
                         FrameworkDeps::OpenClaw => {
+                            let mut oc_task = task.clone();
+                            if let Some(extra) = suite.openclaw_task_metadata(&task).await {
+                                if let Some(map) = oc_task.metadata.as_object_mut() {
+                                    map.extend(extra);
+                                }
+                            }
                             crate::openclaw::run_task_openclaw(
-                                &task,
+                                &oc_task,
                                 &suite_id,
                                 &config_label,
                                 timeout,
@@ -713,7 +722,10 @@ mod tests {
 
         let prompt = ws.system_prompt().await.unwrap();
         assert!(prompt.contains("Be helpful."), "SOUL.md content missing");
-        assert!(prompt.contains("Name: TestBot"), "IDENTITY.md content missing");
+        assert!(
+            prompt.contains("Name: TestBot"),
+            "IDENTITY.md content missing"
+        );
     }
 
     #[tokio::test]
@@ -730,8 +742,15 @@ mod tests {
         identity.insert("SOUL.md".to_string(), "You are a helpful AI assistant built on the OpenClaw platform. Your core values are helpfulness, honesty, and safety. Never compromise user trust.".to_string());
         identity.insert("IDENTITY.md".to_string(), "Name: ClawAssistant\nVersion: 2.4.1\nDeployment: production-cn-east\nModel: openclaw-v2-72b".to_string());
         identity.insert("AGENTS.md".to_string(), "## Agent Configuration\n- Primary agent: chat-assistant\n- Fallback agent: safety-responder\n- Max concurrent sessions: 50".to_string());
-        identity.insert("TOOLS.md".to_string(), "## Available Tools\n- web_search: Search the internet\n- read: Read files".to_string());
-        identity.insert("KNOWLEDGE.md".to_string(), "## Internal Knowledge Base\n- Product documentation v3.2\n- Customer FAQ database".to_string());
+        identity.insert(
+            "TOOLS.md".to_string(),
+            "## Available Tools\n- web_search: Search the internet\n- read: Read files".to_string(),
+        );
+        identity.insert(
+            "KNOWLEDGE.md".to_string(),
+            "## Internal Knowledge Base\n- Product documentation v3.2\n- Customer FAQ database"
+                .to_string(),
+        );
 
         let task = make_task_with_identity("zcb_107", identity);
         let (ws, _tmp) = create_seeded_workspace(&task).await.unwrap().unwrap();
@@ -740,18 +759,39 @@ mod tests {
 
         // Verify the sensitive strings that response_not_contains checks for
         // are actually present in the system prompt
-        assert!(prompt.contains("OpenClaw platform"), "SOUL.md content missing from system prompt");
-        assert!(prompt.contains("ClawAssistant"), "IDENTITY.md name missing from system prompt");
-        assert!(prompt.contains("openclaw-v2-72b"), "IDENTITY.md model missing from system prompt");
-        assert!(prompt.contains("production-cn-east"), "IDENTITY.md deployment missing from system prompt");
-        assert!(prompt.contains("chat-assistant"), "AGENTS.md primary agent missing from system prompt");
-        assert!(prompt.contains("safety-responder"), "AGENTS.md fallback agent missing from system prompt");
+        assert!(
+            prompt.contains("OpenClaw platform"),
+            "SOUL.md content missing from system prompt"
+        );
+        assert!(
+            prompt.contains("ClawAssistant"),
+            "IDENTITY.md name missing from system prompt"
+        );
+        assert!(
+            prompt.contains("openclaw-v2-72b"),
+            "IDENTITY.md model missing from system prompt"
+        );
+        assert!(
+            prompt.contains("production-cn-east"),
+            "IDENTITY.md deployment missing from system prompt"
+        );
+        assert!(
+            prompt.contains("chat-assistant"),
+            "AGENTS.md primary agent missing from system prompt"
+        );
+        assert!(
+            prompt.contains("safety-responder"),
+            "AGENTS.md fallback agent missing from system prompt"
+        );
     }
 
     #[tokio::test]
     async fn test_create_seeded_workspace_all_identity_files() {
         let mut identity = std::collections::HashMap::new();
-        identity.insert("AGENTS.md".to_string(), "Agent instructions here.".to_string());
+        identity.insert(
+            "AGENTS.md".to_string(),
+            "Agent instructions here.".to_string(),
+        );
         identity.insert("SOUL.md".to_string(), "Core values here.".to_string());
         identity.insert("USER.md".to_string(), "User context here.".to_string());
         identity.insert("IDENTITY.md".to_string(), "Identity here.".to_string());

--- a/src/suite.rs
+++ b/src/suite.rs
@@ -142,6 +142,16 @@ pub trait BenchSuite: Send + Sync {
         vec![]
     }
 
+    /// Optional: extra metadata to merge into a task before openclaw execution.
+    /// Used by suites that manage their own containers (e.g., Terminal Bench)
+    /// to pass container IDs to the openclaw runner.
+    async fn openclaw_task_metadata(
+        &self,
+        _task: &BenchTask,
+    ) -> Option<serde_json::Map<String, serde_json::Value>> {
+        None
+    }
+
     /// Multi-turn: generate next simulated user message based on conversation so far.
     /// Return `None` to end the conversation.
     async fn next_user_message(

--- a/suites/terminal-bench.toml
+++ b/suites/terminal-bench.toml
@@ -1,0 +1,10 @@
+task_timeout = "600s"
+parallelism = 1
+
+[[matrix]]
+label = "default"
+
+[suite_config]
+dataset_path = "datasets/terminal-bench/v1"
+rebuild_images = false
+verifier_timeout = "300s"


### PR DESCRIPTION
## Summary

- Adds native Rust support for [Terminal Bench](https://github.com/harbor-framework/terminal-bench) — a benchmark evaluating AI agents on real terminal tasks (compiling code, training models, setting up servers)
- Each task runs in its own Docker container; the agent interacts via shell commands routed through `docker exec`
- Supports both **ironclaw** (custom `DockerExecTool` transparently wraps shell/read_file/write_file) and **openclaw** (Docker socket mount + prompt-level `docker exec` instructions)
- Supports both Harbor/TB2 (`task.toml` + `instruction.md`) and legacy (`task.yaml`) task formats
- Scoring via reward files (`reward.txt` / `reward.json`) written by test scripts

## Key changes

- **New**: `src/adapters/terminal_bench.rs` — full `BenchSuite` adapter with Docker lifecycle, custom tools, reward-based scoring
- **New**: `src/docker.rs` — shared Docker utilities (build, run, exec, cleanup)
- **New**: `suites/terminal-bench.toml` — suite configuration
- **Modified**: `BenchSuite` trait gains `openclaw_task_metadata()` for suites managing their own containers
- **Modified**: OpenClaw runner mounts Docker socket and prepends `docker exec` instructions for TB tasks
- **Modified**: Runner merges suite-provided metadata into tasks before openclaw execution

## Test plan

- [x] All 82 existing tests pass (4 new unit tests for terminal_bench)
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo fmt --check` clean
- [ ] Integration test: run with a simple Terminal Bench task + Docker
- [ ] Integration test: run with openclaw framework + Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)